### PR TITLE
Extract binary from tgz in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:edge as downloader
 RUN apk add --no-cache curl jq
 RUN url=$(curl -s "https://api.github.com/repos/concourse/concourse/releases/latest" \
     | jq -r '.assets[] | select(.name | test("fly.*linux.*amd64.tgz$")) | .browser_download_url') && \
-    curl -L "$url" -o /fly
+    curl -L "$url" -o /fly.tgz && tar -xvf /fly.tgz
 
 FROM alpine:edge
 RUN apk add --no-cache bash tzdata ca-certificates


### PR DESCRIPTION
Signed-off-by: Louis Cloutier <louis.cloutier@qlik.com>

Fixes #1 

This doesn't add tests for `fly` because there's no actual CI and I didn't want to make any decisions there.